### PR TITLE
add alter owner table routine

### DIFF
--- a/src/main/infrastructure/repository/cron/cron_job
+++ b/src/main/infrastructure/repository/cron/cron_job
@@ -1,2 +1,3 @@
 0 3 * * * set -a; . /etc/env_vars; set +a; sh /opt/psql-script/psql_users_remove.sh >> /dev/null 2>&1; sh /opt/psql-script/psql_users_add.sh >> /dev/null 2>&1
 0 3 * * * set -a; . /etc/env_vars; set +a; sh /opt/psql-script/psql_users_alter_group.sh >> /dev/null 2>&1
+0 5 * * * set -a; . /etc/env_vars; set +a; sh /opt/psql-script/psql_alter_table_owner.sh.sh >> /dev/null 2>&1

--- a/src/main/infrastructure/repository/script/psql/psql_alter_table_owner.sh
+++ b/src/main/infrastructure/repository/script/psql/psql_alter_table_owner.sh
@@ -1,0 +1,25 @@
+#!/bin/sh
+
+# Default parameters
+DEBUG=${DEBUG:=true}
+
+echo "[INFO] Initializing alter table owner..."
+${DEBUG} && echo "POSTGRES_DEFAULT_USER=${POSTGRES_DEFAULT_USER}"
+${DEBUG} && echo "POSTGRES_DEFAULT_DATABASE=$POSTGRES_DEFAULT_DATABASE"
+# Initializing user/group variables
+ALTER_OWNER_TABLE_SCHEMAS=$(env | grep "PSQL_ALTER_OWNER" | sed -e "s/PSQL_ALTER_OWNER=//")
+if [ ! -z $ALTER_OWNER_TABLE_SCHEMAS ]; then
+	ALTER_OWNER_TABLE_SCHEMAS=$( echo ${ALTER_OWNER_TABLE_SCHEMAS} | tr "[:upper:]" "[:lower:]" )
+	ALTER_OWNER_TABLE_SCHEMAS=$( echo ${ALTER_OWNER_TABLE_SCHEMAS} | tr "," "\n" )
+	for ALTER_OWNER_TABLE_SCHEMA in $ALTER_OWNER_TABLE_SCHEMAS; do
+		${DEBUG} && echo "ALTER_OWNER_TABLE_SCHEMAS=${ALTER_OWNER_TABLE_SCHEMAS}"
+		SCHEMA_TABLES=$(PGPASSWORD=${POSTGRES_ADMIN_PASSWORD} psql -t -A -q -X -c "select tablename from pg_tables where schemaname='${ALTER_OWNER_TABLE_SCHEMA}';" -U ${POSTGRES_ADMIN_USER} ${POSTGRES_DEFAULT_DATABASE} || true )
+		for SCHEMA_TABLE in $SCHEMA_TABLES; do
+			${DEBUG} && echo "[INFO] MOVING SCHEMA_TABLES=${SCHEMA_TABLES} to POSTGRES_DEFAULT_USER=${POSTGRES_DEFAULT_USER}"
+			PGPASSWORD=${POSTGRES_ADMIN_PASSWORD} psql -t -A -q -X -c "ALTER TABLE ${ALTER_OWNER_TABLE_SCHEMA}.${SCHEMA_TABLE} OWNER TO ${POSTGRES_DEFAULT_USER};" -U ${POSTGRES_ADMIN_USER} ${POSTGRES_DEFAULT_DATABASE} || true 
+		done
+	done
+else
+	echo "[INFO] Skipping alter table owner due conditional..."
+fi
+

--- a/src/main/infrastructure/repository/script/psql/psql_configure.sh
+++ b/src/main/infrastructure/repository/script/psql/psql_configure.sh
@@ -59,6 +59,7 @@ PGPASSWORD=${POSTGRES_DEFAULT_PASSWORD} psql -c "ALTER USER ${POSTGRES_DEFAULT_U
 ./psql_users_remove.sh  || true
 ./psql_users_add.sh  || true
 ./psql_users_alter_group.sh || true
+./psql_alter_table_owner.sh || true
 
 # If stats extension should be confgured.
 ${DEBUG} && echo "ENABLE_STATS=${ENABLE_STATS}"


### PR DESCRIPTION
Adicionei essa rotina para mover o usuario dono das tabelas automaticamente. Acredito que seja útil em cenários como os do data-marts, onde temos um número maior de usuários criando tabelas recorrentemente e não necessariamente mudando o owner delas. Todas as tabelas do schema passados pela env vão para o usuário default do banco.

Para ativar é só passar a env **PSQL_ALTER_OWNER**=\<schemas\> separados por virgulas
ex: PSQL_ALTER_OWNER=public