### PR TITLE
Feature/fix scripts

### DIFF
--- a/src/main/infrastructure/repository/script/psql/psql_users_add.sh
+++ b/src/main/infrastructure/repository/script/psql/psql_users_add.sh
@@ -3,6 +3,12 @@
 # Default parameters.
 DEBUG=${DEBUG:=true}
 DEBUG_OPT=
+ENV_FILE="/local/application.env"
+
+# Update environment variables
+if [ -f "$ENV_FILE" ]; then
+  . "$ENV_FILE"
+fi
 
 # If not exist
 if [ -z "$LDAP_HOST" ]; then

--- a/src/main/infrastructure/repository/script/psql/psql_users_alter_group.sh
+++ b/src/main/infrastructure/repository/script/psql/psql_users_alter_group.sh
@@ -4,6 +4,13 @@
 DEBUG=${DEBUG:=true}
 SKIP_ALTER_GROUP=${SKIP_ALTER_GROUP:=true}
 
+ENV_FILE="/local/application.env"
+
+# Update environment variables
+if [ -f "$ENV_FILE" ]; then
+  . "$ENV_FILE"
+fi
+
 # If not exist
 if [ -z "$LDAP_HOST" ]; then
 	${DEBUG} && echo MOUNTING LDAP_HOST VAR - ${LDAP_URI}:${LDAP_PORT}

--- a/src/main/infrastructure/repository/script/psql/psql_users_remove.sh
+++ b/src/main/infrastructure/repository/script/psql/psql_users_remove.sh
@@ -17,7 +17,7 @@ if [ -z "$LDAP_HOST" ]; then
 fi
 
 # Check if LDAP is up
-ldapsearch -w "${LDAP_PASSWORD}" -D "${LDAP_USER}" -H "ldap://${LDAP_HOST}"  -W -s base -b "" "(objectClass=*)" -o nettimeout=2  >/dev/null 2>&1 \
+ldapsearch -w "${LDAP_PASSWORD}" -D "${LDAP_USER}" -H "ldap://${LDAP_HOST}" -s base -b "" "(objectClass=*)" -o nettimeout=2  >/dev/null 2>&1 \
 && echo "Running psql_users_remove" || { echo "LDAP Server not found, psql_users_remove exiting..."; exit 1; }
 
 # Initializing user/group variables

--- a/src/main/infrastructure/repository/script/psql/psql_users_remove.sh
+++ b/src/main/infrastructure/repository/script/psql/psql_users_remove.sh
@@ -3,12 +3,22 @@
 # Default parameters
 DEBUG=${DEBUG:=true}
 SKIP_DELETE=${SKIP_DELETE:=false}
+ENV_FILE="/local/application.env"
+
+# Update environment variables
+if [ -f "$ENV_FILE" ]; then
+  . "$ENV_FILE"
+fi
 
 # If not exist
 if [ -z "$LDAP_HOST" ]; then
 	${DEBUG} && echo MOUNTING LDAP_HOST VAR - ${LDAP_URI}:${LDAP_PORT}
 	LDAP_HOST=${LDAP_URI}:${LDAP_PORT}
 fi
+
+# Check if LDAP is up
+ldapsearch -w "${LDAP_PASSWORD}" -D "${LDAP_USER}" -H "ldap://${LDAP_HOST}"  -W -s base -b "" "(objectClass=*)" -o nettimeout=2  >/dev/null 2>&1 \
+&& echo "Running psql_users_remove" || { echo "LDAP Server not found, psql_users_remove exiting..."; exit 1; }
 
 # Initializing user/group variables
 USER_READ_GROUP_VARS=$(env | grep "PSQL_READ_SCHEMA_" | sed -e "s/PSQL_READ_SCHEMA_//")


### PR DESCRIPTION
Ajustando os scripts de usuários:
psql_users_remove: Quando o host do ldap não está disponível ele segue a lógica e remove todos os usuários do banco, então vamos checar antes se está disponível.
psql_users_add/users_alter: Como não está fazendo source do arquivo de variáveis, se o host do LDAP muda ele nunca é atualizado na execução deles.